### PR TITLE
Use absolute path to CRT File

### DIFF
--- a/update-cert
+++ b/update-cert
@@ -5,7 +5,7 @@ def openssl_get(domain, param):
     cmd_param=param
     if param == "altnames":
         cmd_param="text"
-    cmd = "openssl x509 -noout -in .getssl/%s/%s.crt -%s" % (domain,domain,cmd_param)
+    cmd = "openssl x509 -noout -in /root/.getssl/%s/%s.crt -%s" % (domain,domain,cmd_param)
     value = subprocess.check_output(cmd, shell=True).strip()
     if param in ['startdate','enddate','fingerprint','serial']:
         return value.split('=')[1]


### PR DESCRIPTION
Calling update-cert from ie. /root/.getssl/example.com fails with:

Error opening Certificate .getssl/example.com/example.com.crt
1435629192:error:02001002:system library:fopen:No such file or directory:bss_file.c:404:fopen('.gets sl/example.com/example.com.crt','re')
1435629192:error:20074002:BIO routines:FILE_CTRL:system lib:bss_file.c:406:
unable to load certificate
Traceback (most recent call last):
  File "/root/update-cert", line 68, in <module>
    openssl_get(domain,'startdate'),
  File "/root/update-cert", line 9, in openssl_get
    value = subprocess.check_output(cmd, shell=True).strip()
  File "/usr/lib/python2.7/subprocess.py", line 573, in check_output
    raise CalledProcessError(retcode, cmd, output=output)
subprocess.CalledProcessError: Command 'openssl x509 -noout -in .getssl/example.com/example.com.crt -startdate' returned non-zero exit status 1
getssl: error running /root/update-cert example.com REF_CaHosExamplecom

Instead of the relative .getssl/.../*.crt, we should use the absolute path /root/.getssl to prevent calls to update-cert from directories other than /root failing.
$HOME/.getssl[...] would be even better, but who's going to run this script as non-root on the UTM anyway?